### PR TITLE
Error on validation for objects with undefined values for attributes

### DIFF
--- a/lib/utils/attributes_validator/index.js
+++ b/lib/utils/attributes_validator/index.js
@@ -19,7 +19,7 @@
  */
 
 var sprintf = require('sprintf');
-var _ = require('lodash');
+var lodashForOwn = require('lodash/forOwn');
 
 var ERROR_MESSAGES = require('../enums').ERROR_MESSAGES;
 var MODULE_NAME = 'ATTRIBUTES_VALIDATOR';
@@ -33,7 +33,7 @@ module.exports = {
    */
   validate: function(attributes) {
     if (typeof attributes === 'object' && !Array.isArray(attributes) && attributes !== null) {
-      _.forEach(attributes, function(value, key) {
+      lodashForOwn(attributes, function(value, key) {
         if (typeof value === 'undefined') {
           throw new Error(sprintf(ERROR_MESSAGES.UNDEFINED_ATTRIBUTE, MODULE_NAME, key));
         }

--- a/lib/utils/attributes_validator/index.js
+++ b/lib/utils/attributes_validator/index.js
@@ -19,6 +19,7 @@
  */
 
 var sprintf = require('sprintf');
+var _ = require('lodash');
 
 var ERROR_MESSAGES = require('../enums').ERROR_MESSAGES;
 var MODULE_NAME = 'ATTRIBUTES_VALIDATOR';
@@ -32,6 +33,11 @@ module.exports = {
    */
   validate: function(attributes) {
     if (typeof attributes === 'object' && !Array.isArray(attributes) && attributes !== null) {
+      _.forEach(attributes, function(value, key) {
+        if (typeof value === 'undefined') {
+          throw new Error(sprintf(ERROR_MESSAGES.UNDEFINED_ATTRIBUTE, MODULE_NAME, key));
+        }
+      });
       return true;
     } else {
       throw new Error(sprintf(ERROR_MESSAGES.INVALID_ATTRIBUTES, MODULE_NAME));

--- a/lib/utils/attributes_validator/tests.js
+++ b/lib/utils/attributes_validator/tests.js
@@ -52,7 +52,7 @@ describe('lib/utils/attributes_validator', function() {
 
       it('should throw an error if attributes contains a key with an undefined value', function() {
         var attributeKey = 'testAttribute';
-        var attributes = {}
+        var attributes = {};
         attributes[attributeKey] = undefined;
 
         assert.throws(function() {

--- a/lib/utils/attributes_validator/tests.js
+++ b/lib/utils/attributes_validator/tests.js
@@ -48,6 +48,17 @@ describe('lib/utils/attributes_validator', function() {
           attributesValidator.validate(invalidInput);
         }, sprintf(ERROR_MESSAGES.INVALID_ATTRIBUTES, 'ATTRIBUTES_VALIDATOR'));
       });
+
+
+      it('should throw an error if attributes contains a key with an undefined value', function() {
+        var attributeKey = 'testAttribute';
+        var attributes = {}
+        attributes[attributeKey] = undefined;
+
+        assert.throws(function() {
+          attributesValidator.validate(attributes);
+        }, sprintf(ERROR_MESSAGES.UNDEFINED_ATTRIBUTE, 'ATTRIBUTES_VALIDATOR', attributeKey));
+      });
     });
   });
 });

--- a/lib/utils/enums/index.js
+++ b/lib/utils/enums/index.js
@@ -27,6 +27,7 @@ exports.LOG_LEVEL = {
 
 exports.ERROR_MESSAGES = {
   INVALID_ATTRIBUTES: '%s: Provided attributes are in an invalid format.',
+  UNDEFINED_ATTRIBUTE: '%s: Provided attribute: %s has an undefined value.',
   INVALID_BUCKETING_ID: '%s: Unable to generate hash for bucketing ID %s: %s',
   INVALID_DATAFILE: '%s: Datafile is invalid: %s',
   INVALID_JSON: '%s: JSON object is not valid.',


### PR DESCRIPTION
If we pass an object as attributes to activate (or other functions) that includes an undefined value for a key then the SDK will fail to generate an impression for that activation.