### PR TITLE
More use of returns instead of var/break

### DIFF
--- a/lib/core/bucketer/index.js
+++ b/lib/core/bucketer/index.js
@@ -131,14 +131,12 @@ module.exports = {
    * @return {string}   Entity ID for bucketing if bucket value is within traffic allocation boundaries, null otherwise
    */
   _findBucket: function(bucketValue, trafficAllocationConfig) {
-    var entityId = null;
     for (var i = 0; i < trafficAllocationConfig.length; i++) {
       if (bucketValue < trafficAllocationConfig[i].endOfRange) {
-        entityId = trafficAllocationConfig[i].entityId;
-        break;
+        return trafficAllocationConfig[i].entityId;
       }
     }
-    return entityId;
+    return null;
   },
 
   /**

--- a/lib/core/condition_evaluator/index.js
+++ b/lib/core/condition_evaluator/index.js
@@ -59,17 +59,15 @@ function evaluate(conditions, userAttributes) {
  * @return {Boolean}                 true if the user attributes match the given conditions
  */
 function andEvaluator(conditions, userAttributes) {
-  var result = true;
   var condition;
   for (var i = 0; i < conditions.length; i++) {
     condition = conditions[i];
     if (!evaluate(condition, userAttributes)) {
-      result = false;
-      break;
+      return false;
     }
   }
 
-  return result;
+  return true;
 }
 
 /**
@@ -95,16 +93,14 @@ function notEvaluator(conditions, userAttributes) {
  * @return {Boolean}                 true if the user attributes match the given conditions
  */
 function orEvaluator(conditions, userAttributes) {
-  var result = false;
   for (var i = 0; i < conditions.length; i++) {
     var condition = conditions[i];
     if (evaluate(condition, userAttributes)) {
-      result = true;
-      break;
+      return true;
     }
   }
 
-  return result;
+  return false;
 }
 
 /**


### PR DESCRIPTION
Similar to 

https://github.com/optimizely/node-sdk/pull/61

This removes `var` placeholders and `break`s in loops with direct `return` statements.