### PR TITLE
Bucketer: Fix LOG_LEVEL.WARN -> LOG_LEVEL.WARNING

### DIFF
--- a/lib/core/bucketer/index.js
+++ b/lib/core/bucketer/index.js
@@ -93,7 +93,7 @@ module.exports = {
       bucketerParams.logger.log(LOG_LEVEL.DEBUG, userHasNoVariationLogMessage);
     } else if (entityId === '' || !bucketerParams.variationIdMap.hasOwnProperty(entityId)) {
       var invalidVariationIdLogMessage = sprintf(LOG_MESSAGES.INVALID_VARIATION_ID, MODULE_NAME);
-      bucketerParams.logger.log(LOG_LEVEL.WARN, invalidVariationIdLogMessage);
+      bucketerParams.logger.log(LOG_LEVEL.WARNING, invalidVariationIdLogMessage);
       return null;
     } else {
       var variationKey = bucketerParams.variationIdMap[entityId].key;


### PR DESCRIPTION
Fixes the only instance of `LOG_LEVEL.WARN`, which is undefined. The available level is `LOG_LEVEL.WARNING`: https://github.com/optimizely/node-sdk/blob/master/lib/plugins/logger/enums.js#L20