### PR TITLE
Update request dependency with patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "json-schema": "^0.2.3",
     "lodash": "^4.13.1",
     "murmurhash": "0.0.2",
-    "request": "~2.81.0",
+    "request": "^2.85.0",
     "sprintf": "^0.1.5",
     "uuid": "~3.0.1"
   },


### PR DESCRIPTION
Hello! I work for a company that leverages this SDK and ran into what appears to be a security vulnerability from a transitive dependency.

We run [`nsp check`](https://github.com/nodesecurity/nsp) to audit our dependencies.

We pull in `optimizely-client-sdk@1.6.0`, which in turn pulls in the server SDK. The server SDK is flagged for us because of a vulnerability in hoek, which is transitive from `request`.

![image](https://user-images.githubusercontent.com/1242640/38592391-a3ccfb68-3cf0-11e8-8fa7-b515b141212f.png)

Upgrading hoek removes the issue.

This can't really be verified using a unit test, but can be checked using the following:

1. Clone the repo
2. Run `nsp check` in the repo root of master (either via `npx` or via a global installation). Should see something similar to the above screenshot.
3. Checkout this branch
4. Run `nsp check` again. Should see "No known vulnerabilities found"

I think this will also require a corresponding version change in the client SDK's 1.6 branch to use a caret with the published version of this, should it get merged.

Let me know if you have any questions / concerns!

Best,
Austin